### PR TITLE
Preserve case in default Json serialization

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Controller.cs
+++ b/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Controller.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -285,7 +286,10 @@ namespace Microsoft.AspNetCore.Mvc
         [NonAction]
         public virtual JsonResult Json(object data)
         {
-            return new JsonResult(data);
+            // force Newtonsoft to use the default contract resolver (don't overwrite field names)
+            var serializerSettings = new JsonSerializerSettings();
+            serializerSettings.ContractResolver = new DefaultContractResolver();
+            return new JsonResult(data, serializerSettings);
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.FunctionalTests/JsonResultTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.FunctionalTests/JsonResultTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal("{\"message\":\"hello\"}", content);
+            Assert.Equal("{\"Message\":\"hello\"}", content);
         }
 
         // Using an Accept header can't force Json to not be Json. If your accept header doesn't jive with the
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal("{\"message\":\"hello\"}", content);
+            Assert.Equal("{\"Message\":\"hello\"}", content);
         }
 
         // If the object is null, it will get formatted as JSON. NOT as a 204/NoContent


### PR DESCRIPTION
It seems like the default behavior should be to preserve the case of the fields in objects that get serialized, or else make it very clear in the
documentation that the case of fields in the produced Json will get converted to camelCase. This commit introduces the former fix.